### PR TITLE
Add docker-compose.yml

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,6 +220,8 @@ GEM
     minitest (5.16.3)
     nokogiri (1.13.8-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.8-x86_64-linux)
+      racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
@@ -261,6 +263,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-linux-musl
 
 DEPENDENCIES
   github-pages

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# ESMeta Official Homepage
+
+This repository contains the official ESMeta homepage, built with [Jekyll](https://jekyllrb.com/), deployed via GitHub Pages.
+
+## Running Locally
+
+If you’re already using Docker, you can start the site without installing and configuring Ruby and Jekyll:
+```shell
+$ docker compose up
+```
+
+If you prefer to run it without Docker, please refer to the Jekyll installation guides: [EN](https://jekyllrb.com/docs/installation/)/[KO](https://jekyllrb-ko.github.io/docs/installation)
+
+Once Jekyll is installed, you can run the site locally with the following command:
+```shell
+$ bundle exec jekyll serve
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+
+services:
+  jekyll:
+    image: jekyll/builder
+    command: jekyll serve --watch --force_polling --host 0.0.0.0
+    ports:
+      - "4000:4000"
+    volumes:
+      - .:/srv/jekyll
+    working_dir: /srv/jekyll


### PR DESCRIPTION
This PR adds docker-compose.yml to help homepage maintainers to run jekyll on their machines